### PR TITLE
Bump python requirements to 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 readme = "README.md"
 license = {file = "LICENSE"}
 dependencies = [


### PR DESCRIPTION
This MR sets the upper limit of required Python to 3.13, as it is now the officially supported version.